### PR TITLE
Remove test code 'G' from the PiLiteEmulator

### DIFF
--- a/Python_Examples/PiLiteEmulator.py
+++ b/Python_Examples/PiLiteEmulator.py
@@ -407,10 +407,6 @@ class PiLITE(object):
                     elif str(self.commandbuffer).startswith("LL,OFF"):
                         self.ledClear()
 
-                elif self.commandchar == 'G':	# Test code - switch Digital 14 on
-                    pinMode(14,OUTPUT)
-                    digitalWrite(14,HIGH)
-
                 else:	# not a valid command
                     pass
                 self.status = self.STATUS_NORMAL


### PR DESCRIPTION
It makes no sense for the emulator to include this, and just triggers a NameError python exception if you try using it.
