### PR TITLE
Fix exception handling in python demos

### DIFF
--- a/Python_Examples/BarScroll.py
+++ b/Python_Examples/BarScroll.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import serial, time
+import serial, time, sys
 
 
 s = serial.Serial()
@@ -12,7 +12,7 @@ s.port = "/dev/ttyAMA0"
 try:
     s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
 
 s.write("$$$ALL,OFF\r")

--- a/Python_Examples/BarUpDown.py
+++ b/Python_Examples/BarUpDown.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import serial, time
+import serial, time, sys
 
 
 s = serial.Serial()
@@ -12,7 +12,7 @@ s.port = "/dev/ttyAMA0"
 try:
     s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
 
 s.write("$$$ALL,OFF\r")

--- a/Python_Examples/Bargraph_tk.py
+++ b/Python_Examples/Bargraph_tk.py
@@ -2,7 +2,7 @@
 
 from Tkinter import *
 import serial
-
+import sys
 
 def barSet(num, value):
     s.write("$$$B{},{}\r".format(num, value))
@@ -15,7 +15,7 @@ s.port = "/dev/ttyAMA0"
 try:
             s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
 
 s.write("$$$ALL,OFF\r")

--- a/Python_Examples/Pacman.py
+++ b/Python_Examples/Pacman.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import serial, time
+import serial, time, sys
 
 
 s = serial.Serial()
@@ -12,7 +12,7 @@ s.port = "/dev/ttyAMA0"
 try:
     s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
 
 s.write("$$$ALL,OFF\r")

--- a/Python_Examples/VUSample.py
+++ b/Python_Examples/VUSample.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-import serial, time
+import serial, time, sys
 
 
 s = serial.Serial()
@@ -12,7 +12,7 @@ s.port = "/dev/ttyAMA0"
 try:
     s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
 
 s.write("$$$ALL,OFF\r")

--- a/Python_Examples/VU_tk.py
+++ b/Python_Examples/VU_tk.py
@@ -2,7 +2,7 @@
 
 from Tkinter import *
 import serial
-
+import sys
 
 def vuSet(num, value):
     s.write("$$$V{},{}\r".format(num, value))
@@ -16,7 +16,7 @@ s.port = "/dev/ttyAMA0"
 try:
     s.open()
 except serial.SerialException, e:
-    sys.stderr.write("could not open port %r: %s\n" % (port, e))
+    sys.stderr.write("could not open port %r: %s\n" % (s.port, e))
     sys.exit(1)
                 
 s.write("$$$ALL,OFF\r")


### PR DESCRIPTION
the python demos write to sys.stderr if the serial connection fails, but sys is not imported
also, the error messages print out "port" instead of "s.port"
